### PR TITLE
allow to use SHT_REAL_NORM normalization

### DIFF
--- a/src/SHTns.jl
+++ b/src/SHTns.jl
@@ -63,11 +63,13 @@ for (type, enumtype) in [(:Orthonormal, :sht_orthonormal), (:FourPi, :sht_fourpi
         """
         Base.@kwdef struct $(type)<:SHTnsNorm 
             cs_phase::Bool=true
+            real_norm::Bool=false
         end
 
         function Base.convert(::Type{shtns_norm}, x::$(type))
             norm = $(enumtype)
             !x.cs_phase && (norm += SHT_NO_CS_PHASE)
+            x.real_norm && (norm += SHT_REAL_NORM)
             return norm
         end
     end


### PR DESCRIPTION
Expose in the julia interface the possibility to use "real normalization" :

`cfg = SHTns.SHTnsCfg(13; norm = SHTns.Orthonormal(; real_norm=true))`

