### PR TITLE
fix CUDA wrapping

### DIFF
--- a/ext/SHTnsCUDAExt/sht.jl
+++ b/ext/SHTnsCUDAExt/sht.jl
@@ -14,11 +14,11 @@ function cu_SHsphtor_to_spat(cfg, Slm::CuVector{Complex{Float64}}, Tlm::CuVector
     ccall((:cu_SHsphtor_to_spat, libshtns[]), Nothing, (shtns_cfg,CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{Float64},CuPtr{Float64}, Clong), cfg, Slm, Tlm, Vt, Vp, lmax)
 end
 
-function spat_to_SHqst(cfg, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, Qlm::CuVector{Complex{Float64}}, Slm::CuVector{Complex{Float64}}, Tlm::CuVector{Complex{Float64}}, lmax)
+function cu_spat_to_SHqst(cfg, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, Qlm::CuVector{Complex{Float64}}, Slm::CuVector{Complex{Float64}}, Tlm::CuVector{Complex{Float64}}, lmax)
     ccall((:cu_spat_to_SHqst, libshtns[]), Nothing, (shtns_cfg,CuPtr{Float64},CuPtr{Float64},CuPtr{Float64},CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{ComplexF64}, Clong), cfg, Vr, Vt, Vp, Qlm, Slm, Tlm, lmax)
 end
 
-function SHqst_to_spat(cfg, Qlm::CuVector{Complex{Float64}}, Slm::CuVector{Complex{Float64}}, Tlm::CuVector{Complex{Float64}}, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, lmax)
+function cu_SHqst_to_spat(cfg, Qlm::CuVector{Complex{Float64}}, Slm::CuVector{Complex{Float64}}, Tlm::CuVector{Complex{Float64}}, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, lmax)
     ccall((:cu_SHqst_to_spat, libshtns[]), Nothing, (shtns_cfg,CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{Float64},CuPtr{Float64},CuPtr{Float64}, Clong), cfg, Qlm, Slm, Tlm, Vr, Vt, Vp, lmax)
 end
 


### PR DESCRIPTION
When trying to use SHTns with CUDA, i got the following error :

```
ERROR: LoadError: UndefVarError: `cu_SHqst_to_spat` not defined in `SHTnsCUDAExt`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] synth!(cfg::SHTns.SHTnsCfg{Real, SHTns.Orthonormal, SHTns.QuickInit}, qlm::CuArray{ComplexF64, 1, CUDA.DeviceMemory}, slm::CuArray{ComplexF64, 1, CUDA.DeviceMemory}, tlm::CuArray{ComplexF64, 1, CUDA.DeviceMemory}, ur::CuArray{Float64, 2, CUDA.DeviceMemory}, utheta::CuArray{Float64, 2, CUDA.DeviceMemory}, uphi::CuArray{Float64, 2, CUDA.DeviceMemory})
   @ SHTnsCUDAExt ~/.julia/packages/SHTns/g4u8S/ext/SHTnsCUDAExt/synth.jl:60
 [2] synth(cfg::SHTns.SHTnsCfg{Real, SHTns.Orthonormal, SHTns.QuickInit}, qlm::CuArray{ComplexF64, 1, CUDA.DeviceMemory}, slm::CuArray{ComplexF64, 1, CUDA.DeviceMemory}, tlm::CuArray{ComplexF64, 1, CUDA.DeviceMemory})
   @ SHTnsCUDAExt ~/.julia/packages/SHTns/g4u8S/ext/SHTnsCUDAExt/synth.jl:41
```

the fix is to add a missing "cu_" in two method name