### PR TITLE
fix: add missing function to support howmany parameter with CUDA

### DIFF
--- a/ext/SHTnsCUDAExt/analys.jl
+++ b/ext/SHTnsCUDAExt/analys.jl
@@ -70,7 +70,7 @@ end
 
 function analys!(cfg::SHTnsCfg, v::CuArray{Float64}, qlm::CuMatrix{ComplexF64})
     @assert cfg.shtype.gpu
-    @assert cfg.lmax == sizef(qlm, 1)
+    @assert cfg.lmax == size(qlm, 1)
     @assert cfg.howmany == size(qlm, 2)
     return cu_spat_to_SH(cfg.cfg, v, qlm, cfg.lmax)
 end
@@ -78,8 +78,8 @@ end
 
 function analys!(cfg::SHTnsCfg, utheta::T, uphi::T, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
     @assert cfg.shtype.gpu
-    @assert cfg.lmax == sizef(slm, 1)
-    @assert cfg.lmax == sizef(tlm, 1)
+    @assert cfg.lmax == size(slm, 1)
+    @assert cfg.lmax == size(tlm, 1)
     @assert cfg.howmany == size(slm, 2)
     @assert cfg.howmany == size(tlm, 2)
     return cu_spat_to_SHsphtor(cfg.cfg, utheta, uphi, slm, tlm, cfg.lmax)
@@ -87,9 +87,9 @@ end
 
 function analys!(cfg::SHTnsCfg, ur::T, utheta::T, uphi::T, qlm::CuMatrix{ComplexF64}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
     @assert cfg.shtype.gpu
-    @assert cfg.lmax == sizef(qlm, 1)
-    @assert cfg.lmax == sizef(slm, 1)
-    @assert cfg.lmax == sizef(tlm, 1)
+    @assert cfg.lmax == size(qlm, 1)
+    @assert cfg.lmax == size(slm, 1)
+    @assert cfg.lmax == size(tlm, 1)
     @assert cfg.howmany == size(qlm, 2)
     @assert cfg.howmany == size(slm, 2)
     @assert cfg.howmany == size(tlm, 2)

--- a/ext/SHTnsCUDAExt/analys.jl
+++ b/ext/SHTnsCUDAExt/analys.jl
@@ -70,17 +70,29 @@ end
 
 function analys!(cfg::SHTnsCfg, v::CuArray{Float64}, qlm::CuMatrix{ComplexF64})
     @assert cfg.shtype.gpu
+    @assert cfg.lmax == sizef(qlm, 1)
+    @assert cfg.howmany == size(qlm, 2)
     return cu_spat_to_SH(cfg.cfg, v, qlm, cfg.lmax)
 end
 
 
 function analys!(cfg::SHTnsCfg, utheta::T, uphi::T, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
     @assert cfg.shtype.gpu
+    @assert cfg.lmax == sizef(slm, 1)
+    @assert cfg.lmax == sizef(tlm, 1)
+    @assert cfg.howmany == size(slm, 2)
+    @assert cfg.howmany == size(tlm, 2)
     return cu_spat_to_SHsphtor(cfg.cfg, utheta, uphi, slm, tlm, cfg.lmax)
 end
 
 function analys!(cfg::SHTnsCfg, ur::T, utheta::T, uphi::T, qlm::CuMatrix{ComplexF64}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
     @assert cfg.shtype.gpu
+    @assert cfg.lmax == sizef(qlm, 1)
+    @assert cfg.lmax == sizef(slm, 1)
+    @assert cfg.lmax == sizef(tlm, 1)
+    @assert cfg.howmany == size(qlm, 2)
+    @assert cfg.howmany == size(slm, 2)
+    @assert cfg.howmany == size(tlm, 2)
     return cu_spat_to_SHqst(cfg.cfg, ur, utheta, uphi, qlm, slm, tlm, cfg.lmax)
 end
 

--- a/ext/SHTnsCUDAExt/analys.jl
+++ b/ext/SHTnsCUDAExt/analys.jl
@@ -68,6 +68,22 @@ function analys!(cfg::SHTnsCfg, ur::T, utheta::T, uphi::T, qlm::CuVector{Complex
     return cu_spat_to_SHqst(cfg.cfg, ur, utheta, uphi, qlm, slm, tlm, cfg.lmax)
 end
 
+function analys!(cfg::SHTnsCfg, v::CuArray{Float64}, qlm::CuMatrix{ComplexF64})
+    @assert cfg.shtype.gpu
+    return cu_spat_to_SH(cfg.cfg, v, qlm, cfg.lmax)
+end
+
+
+function analys!(cfg::SHTnsCfg, utheta::T, uphi::T, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
+    @assert cfg.shtype.gpu
+    return cu_spat_to_SHsphtor(cfg.cfg, utheta, uphi, slm, tlm, cfg.lmax)
+end
+
+function analys!(cfg::SHTnsCfg, ur::T, utheta::T, uphi::T, qlm::CuMatrix{ComplexF64}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}) where {T<:CuArray{Float64}}
+    @assert cfg.shtype.gpu
+    return cu_spat_to_SHqst(cfg.cfg, ur, utheta, uphi, qlm, slm, tlm, cfg.lmax)
+end
+
 #complex to complex not available for CUDA (status: SHTns v3.7)
 
 # function analys!(cfg::SHTnsCfg, v::CuArray{ComplexF64}, qlm::CuVector{ComplexF64})

--- a/ext/SHTnsCUDAExt/sht.jl
+++ b/ext/SHTnsCUDAExt/sht.jl
@@ -23,3 +23,28 @@ function cu_SHqst_to_spat(cfg, Qlm::CuVector{Complex{Float64}}, Slm::CuVector{Co
 end
 
 
+function cu_spat_to_SH(cfg, Vr::CuArray{Float64}, Qlm::CuMatrix{Complex{Float64}}, lmax)
+    ccall((:cu_spat_to_SH, libshtns[]), Nothing, (shtns_cfg, CuPtr{Float64}, CuPtr{Complex{Float64}}, Clong), cfg, Vr, Qlm, lmax)
+end
+
+function cu_SH_to_spat(cfg, Qlm::CuMatrix{Complex{Float64}}, Vr::CuArray{Float64}, lmax)
+    ccall((:cu_SH_to_spat, libshtns[]), Nothing, (shtns_cfg, CuPtr{Complex{Float64}}, CuPtr{Float64}, Clong), cfg, Qlm, Vr, lmax)
+end
+
+function cu_spat_to_SHsphtor(cfg, Vt::CuArray{Float64}, Vp::CuArray{Float64}, Slm::CuMatrix{Complex{Float64}}, Tlm::CuMatrix{Complex{Float64}}, lmax)
+    ccall((:cu_spat_to_SHsphtor, libshtns[]), Nothing, (shtns_cfg,CuPtr{Float64},CuPtr{Float64},CuPtr{ComplexF64},CuPtr{ComplexF64}, Clong), cfg, Vt, Vp, Slm, Tlm, lmax)
+end
+
+function cu_SHsphtor_to_spat(cfg, Slm::CuMatrix{Complex{Float64}}, Tlm::CuMatrix{Complex{Float64}}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, lmax)
+    ccall((:cu_SHsphtor_to_spat, libshtns[]), Nothing, (shtns_cfg,CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{Float64},CuPtr{Float64}, Clong), cfg, Slm, Tlm, Vt, Vp, lmax)
+end
+
+function cu_spat_to_SHqst(cfg, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, Qlm::CuMatrix{Complex{Float64}}, Slm::CuMatrix{Complex{Float64}}, Tlm::CuMatrix{Complex{Float64}}, lmax)
+    ccall((:cu_spat_to_SHqst, libshtns[]), Nothing, (shtns_cfg,CuPtr{Float64},CuPtr{Float64},CuPtr{Float64},CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{ComplexF64}, Clong), cfg, Vr, Vt, Vp, Qlm, Slm, Tlm, lmax)
+end
+
+function cu_SHqst_to_spat(cfg, Qlm::CuMatrix{Complex{Float64}}, Slm::CuMatrix{Complex{Float64}}, Tlm::CuMatrix{Complex{Float64}}, Vr::CuArray{Float64}, Vt::CuArray{Float64}, Vp::CuArray{Float64}, lmax)
+    ccall((:cu_SHqst_to_spat, libshtns[]), Nothing, (shtns_cfg,CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{ComplexF64},CuPtr{Float64},CuPtr{Float64},CuPtr{Float64}, Clong), cfg, Qlm, Slm, Tlm, Vr, Vt, Vp, lmax)
+end
+
+

--- a/ext/SHTnsCUDAExt/synth.jl
+++ b/ext/SHTnsCUDAExt/synth.jl
@@ -61,6 +61,23 @@ function synth!(cfg::SHTnsCfg{Real,T,N}, qlm::CuVector{ComplexF64}, slm::CuVecto
     return ur, utheta, uphi
 end
 
+function synth!(cfg::SHTnsCfg{Real,T,N}, qlm::CuMatrix{ComplexF64}, v::CuArray{Float64}) where {T,N}
+    @assert cfg.shtype.gpu
+    cu_SH_to_spat(cfg.cfg, qlm, v, cfg.lmax)
+    return v
+end
+
+function synth!(cfg::SHTnsCfg{Real,T,N}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}, utheta::Tv, uphi::Tv) where {T,N,Tv<:CuArray{Float64}}
+    @assert cfg.shtype.gpu
+    cu_SHsphtor_to_spat(cfg.cfg, slm, tlm, utheta, uphi, cfg.lmax)
+    return utheta, uphi
+end
+
+function synth!(cfg::SHTnsCfg{Real,T,N}, qlm::CuMatrix{ComplexF64}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}, ur::Tv, utheta::Tv, uphi::Tv) where {T,N,Tv<:CuArray{Float64}}
+    @assert cfg.shtype.gpu
+    cu_SHqst_to_spat(cfg.cfg, qlm, slm, tlm, ur, utheta, uphi, cfg.lmax)
+    return ur, utheta, uphi
+end
 
 #complex to complex not available for CUDA (status: SHTns v3.7)
 

--- a/ext/SHTnsCUDAExt/synth.jl
+++ b/ext/SHTnsCUDAExt/synth.jl
@@ -63,18 +63,24 @@ end
 
 function synth!(cfg::SHTnsCfg{Real,T,N}, qlm::CuMatrix{ComplexF64}, v::CuArray{Float64}) where {T,N}
     @assert cfg.shtype.gpu
+    @assert cfg.howmany == size(tlm, 2)
     cu_SH_to_spat(cfg.cfg, qlm, v, cfg.lmax)
     return v
 end
 
 function synth!(cfg::SHTnsCfg{Real,T,N}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}, utheta::Tv, uphi::Tv) where {T,N,Tv<:CuArray{Float64}}
     @assert cfg.shtype.gpu
+    @assert cfg.howmany == size(slm, 2)
+    @assert cfg.howmany == size(tlm, 2)
     cu_SHsphtor_to_spat(cfg.cfg, slm, tlm, utheta, uphi, cfg.lmax)
     return utheta, uphi
 end
 
 function synth!(cfg::SHTnsCfg{Real,T,N}, qlm::CuMatrix{ComplexF64}, slm::CuMatrix{ComplexF64}, tlm::CuMatrix{ComplexF64}, ur::Tv, utheta::Tv, uphi::Tv) where {T,N,Tv<:CuArray{Float64}}
     @assert cfg.shtype.gpu
+    @assert cfg.howmany == size(qlm, 2)
+    @assert cfg.howmany == size(slm, 2)
+    @assert cfg.howmany == size(tlm, 2)
     cu_SHqst_to_spat(cfg.cfg, qlm, slm, tlm, ur, utheta, uphi, cfg.lmax)
     return ur, utheta, uphi
 end


### PR DESCRIPTION
This PR adds some missing functions when wanting to use SHTns.jl with CUDA and parameter `hownmany > 1`.

It just extends what was already done for the CPU part applying it with CUDA types.